### PR TITLE
Adding REST API routes for wordpress menus

### DIFF
--- a/cioos-siooc-wordpress-theme/inc/customizer.php
+++ b/cioos-siooc-wordpress-theme/inc/customizer.php
@@ -64,6 +64,32 @@ function cioos_customize_register( $wp_customize ) {
 		'label' => __( 'R.A. CKAN Base URL' ),
 		'description' => __( 'Pulls a list of data contributors from the referenced CKAN organization list that contain at least 1 dataset.  Example: https://catalogue.[hostname]/ or https://[hostname]/ckan/.  Use the [ckan_organizations] shortcode to place the list in a page/post.' ),
 	) );
+	
+	$ra_menus = array();
+	// print("<pre>");
+	foreach(wp_get_nav_menus() as $ra_menu_item){
+		$ra_menus[$ra_menu_item->slug] = $ra_menu_item->name;
+		// print($ra_menu_item->slug);
+	}
+	// print("</pre>");
+	
+	$wp_customize->add_setting( 'ra_menu_en', array() );
+	$wp_customize->add_control( 'ra_menu_en', array(
+		'type' => 'select',
+		'section' => 'title_tagline', 
+		'label' => __( 'R.A. English menu selector' ),
+		'choices' => $ra_menus,
+		'description' => __( 'Makes the contents of the selected menu available via the Wordpress REST API in JSON format for consumption by CKAN to create consistent menus' ),
+	) );
+	
+	$wp_customize->add_setting( 'ra_menu_fr', array() );
+	$wp_customize->add_control( 'ra_menu_fr', array(
+		'type' => 'select',
+		'section' => 'title_tagline', 
+		'label' => __( 'R.A. French menu selector' ),
+		'choices' => $ra_menus,
+		'description' => __( 'Makes the contents of the selected menu available via the Wordpress REST API in JSON format for consumption by CKAN to create consistent menus' ),
+	) );
 
 	$wp_customize->add_setting( 'search_enable', array(
 		'default' => false,
@@ -265,3 +291,25 @@ function fetch_ckan_organizations(){
 }
 
 add_shortcode('ckan_organizations', 'fetch_ckan_organizations');
+
+function get_menu_en() {
+    # uses slug as set in the RA menu selector options
+    return wp_get_nav_menu_items(get_theme_mod('ra_menu_en'));
+}
+
+function get_menu_fr() {
+    # uses slug as set in the RA menu selector options
+    return wp_get_nav_menu_items(get_theme_mod('ra_menu_fr'));
+}
+
+add_action( 'rest_api_init', function () {
+	register_rest_route( 'ra', '/menu/en', array(
+		'methods' => 'GET',
+		'callback' => 'get_menu_en',
+	) );
+
+	register_rest_route( 'ra', '/menu/fr', array(
+		'methods' => 'GET',
+		'callback' => 'get_menu_fr',
+	) );
+} );

--- a/cioos-siooc-wordpress-theme/inc/customizer.php
+++ b/cioos-siooc-wordpress-theme/inc/customizer.php
@@ -67,6 +67,7 @@ function cioos_customize_register( $wp_customize ) {
 	
 	$ra_menus = array();
 	// print("<pre>");
+	$ra_menus[''] = ' - none - ';
 	foreach(wp_get_nav_menus() as $ra_menu_item){
 		$ra_menus[$ra_menu_item->slug] = $ra_menu_item->name;
 		// print($ra_menu_item->slug);
@@ -292,14 +293,57 @@ function fetch_ckan_organizations(){
 
 add_shortcode('ckan_organizations', 'fetch_ckan_organizations');
 
+// Reformats the output of 
+function get_ra_menu($ra_menu_slug) {
+	// Fetch menu items as defined in the RA Menu Selector setting
+	$menu = wp_get_nav_menu_items(get_theme_mod($ra_menu_slug));
+
+	$return_val = array();
+
+	foreach($menu as $menu_id => $menu_item){
+		$id = $menu_item->ID;
+		$parent_id = (int)$menu_item->menu_item_parent;
+		$new_menu_item = array();
+		$new_menu_item["post_title"] = $menu_item->post_title;
+		$new_menu_item["title"] = $menu_item->title;
+		$new_menu_item["url"] = $menu_item->url;
+		$new_menu_item["menu_order"] = $menu_item->menu_order;
+		$new_menu_item["sub_menu_items"] = null;
+
+		// Root items have a parent ID of 0
+		if ($parent_id === 0) {
+			$return_val[$id] = $new_menu_item;
+		}
+		else{
+			$return_val[$parent_id]["sub_menu_items"][$id] = $new_menu_item;
+		}
+	}
+	
+	// https://stackoverflow.com/a/2699159
+	usort($return_val, function($a, $b) {
+		return $a['menu_order'] <=> $b['menu_order'];
+	});
+
+	foreach($return_val as $menu_id => $menu_item){
+		if($menu_item["sub_menu_items"]){
+			usort($menu_item["sub_menu_items"], function($a, $b) {
+				return $a['menu_order'] <=> $b['menu_order'];
+			});
+		}
+
+		$return_val[$menu_id]["sub_menu_items"] = $menu_item["sub_menu_items"];
+	}
+
+    return $return_val;
+}
+
+// Shortcuts for the French and English menus
 function get_menu_en() {
-    # uses slug as set in the RA menu selector options
-    return wp_get_nav_menu_items(get_theme_mod('ra_menu_en'));
+    return get_ra_menu('ra_menu_en');
 }
 
 function get_menu_fr() {
-    # uses slug as set in the RA menu selector options
-    return wp_get_nav_menu_items(get_theme_mod('ra_menu_fr'));
+    return get_ra_menu('ra_menu_fr');
 }
 
 add_action( 'rest_api_init', function () {


### PR DESCRIPTION
Extends the Wordpress REST API to add routes for menu information in JSON format.  This information can be consumed by CKAN and other applications external to wordpress so that menus may be consistently maintained by treating Wordpress as the authoritative source for this information.

Menu information will be displayed in an order mirroring the configuration inside Wordpress including nesting.

In order to enable these routes the appropriate source menus must be specified in the theme options by selecting them from a drop down menu.

**Routes:**
 - /wp-json/ra/menu/en
 - /wp-json/ra/menu/fr

**Example output:**
```
[
  {
    "post_title": "Home",
    "title": "Home",
    "url": "https://cioos.local/",
    "menu_order": 1,
    "sub_menu_items": null
  },
  {
    "post_title": "",
    "title": "Root Level Page",
    "url": "https://cioos.local/root-level-page/",
    "menu_order": 2,
    "sub_menu_items": [
      {
        "post_title": "",
        "title": "Sub-level Page",
        "url": "https://cioos.local/sub-level-page/",
        "menu_order": 3,
        "sub_menu_items": null
      },
      {
        "post_title": "",
        "title": "More Stuff",
        "url": "https://cioos.local/more-stuff/",
        "menu_order": 4,
        "sub_menu_items": null
      }
    ]
  },
  {
    "post_title": "",
    "title": "Sample Page",
    "url": "https://cioos.local/sample-page/",
    "menu_order": 5,
    "sub_menu_items": [
      {
        "post_title": "",
        "title": "Various Things",
        "url": "https://cioos.local/various-things/",
        "menu_order": 6,
        "sub_menu_items": null
      }
    ]
  },
  {
    "post_title": "",
    "title": "Privacy",
    "url": "https://cioos.local/en/privacy/",
    "menu_order": 7,
    "sub_menu_items": null
  }
]
```